### PR TITLE
move the cursor to the next line after running

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,9 @@ function activate(context) {
       .replace(/\\/g, '\\\\') // escape quotes
       .replace(/'/g, "'\\''") // escape quotes
       .replace(/\"/g, '\\"');
+    const position = editor.selection.active;
+    let newPosition = position.with(position.line + 1, 0);
+    editor.selection = new vscode.Selection(newPosition, newPosition);
     // console.log('textToPaste', textToPaste);
     // console.log(editor.selections);
 


### PR DESCRIPTION
Simply moves the cursor to the next line after running...

This then allows you to run the command on the next line without having to move the cursor down, thereby allowing you go run an entire script by repeatedly hitting the shortcut for run-external.